### PR TITLE
Add support for diagonal directions

### DIFF
--- a/rsi/direction.py
+++ b/rsi/direction.py
@@ -7,14 +7,32 @@ class Direction(Enum):
     EAST = 2
     WEST = 3
 
+    SOUTH_EAST = 4
+    SOUTH_WEST = 5
+    NORTH_EAST = 6
+    NORTH_WEST = 7
+
     def to_byond(self) -> int:
+        BY_NORTH = 1
+        BY_SOUTH = 2
+        BY_EAST = 4
+        BY_WEST = 8
+
         if self == Direction.NORTH:
-            return 1
+            return BY_NORTH
         elif self == Direction.SOUTH:
-            return 2
+            return BY_SOUTH
         elif self == Direction.EAST:
-            return 4
+            return BY_EAST
         elif self == Direction.WEST:
-            return 8
+            return BY_WEST
+        elif self == Direction.SOUTH_EAST:
+            return BY_SOUTH | BY_EAST
+        elif self == Direction.SOUTH_WEST:
+            return BY_SOUTH | BY_WEST
+        elif self == Direction.NORTH_EAST:
+            return BY_NORTH | BY_EAST
+        elif self == Direction.NORTH_WEST:
+            return BY_NORTH | BY_WEST
         else:
             raise ValueError()

--- a/rsi/rsi.py
+++ b/rsi/rsi.py
@@ -179,9 +179,6 @@ class Rsi(object):
         rsi = Rsi((dmi.icon_width, dmi.icon_height))
 
         for dmstate in dmi.states.values():
-            if dmstate.dirs == 8:
-                continue
-
             rsstate = rsi.new_state(dmstate.dirs, dmstate.name)  # type: State
 
             # BYOND does not permit direction specific delays so this is easy.

--- a/spec/RSI.md
+++ b/spec/RSI.md
@@ -36,20 +36,24 @@ Other than identifiers, a state has two other fields in relation to the actual s
 Key | Meaning
 --- | -------
 `flags` | An associative list of `key: object` for defining extra data. There is currently no usage yet. Optional.
-`directions` | A number corresponding to the amount of directions a state has. This should only be a `1` or a `4`.
+`directions` | A number corresponding to the amount of directions a state has. This should be a `1`, a `4` or an `8`.
 `delays` | Can be left out. If defined, a list of lists of delays for an animated icon state. Each list in the list corresponds to a direction. The delays are floats and represent seconds.
 
 States are always ordered alphabetically by their corresponding file name.
 
 #### Directions
 
-There are currently two supported direction types: `1` (no directions) and `4` (North South East West).
+There are currently three supported direction types: `1` (no directions), `4` (North South East West), and `8` (North South East West plus diagonals).
 These directions are ordered (for layout in the `delays` field and ordering in the sprite sheet) in the following order:
 
 * South
 * North
 * East
 * West
+* South East
+* South West
+* North East
+* North West
 
 #### Sprite sheet
 


### PR DESCRIPTION
Used heavily by SS13 for piping.

Since the direction indexes are `4`-`7`, it makes no changes to four-direction textures.