### PR TITLE
Remove selector support

### DIFF
--- a/rsi/helpers.py
+++ b/rsi/helpers.py
@@ -1,8 +1,0 @@
-from typing import List, Optional
-
-
-def state_name(name: str, selectors: Optional[List[str]] = None) -> str:
-    if selectors:
-        name += "+" + "+".join(sorted(selectors))
-
-    return name

--- a/rsi/state.py
+++ b/rsi/state.py
@@ -1,17 +1,12 @@
 from typing import List, Tuple, Dict, Any
 from PIL import Image
-from .helpers import state_name
-
 
 class State(object):
     def __init__(self,
                  name: str,
-                 selectors: List[str],
                  size: Tuple[int, int],
                  directions: int = 1) -> None:
         self.name = name  # type: str
-        self.selectors = selectors  # type: List[str]
-        self.full_name = state_name(self.name, self.selectors)  # type: str
         self.flags = {}  # type: Dict[str, Any]
         self.size = size  # type: Tuple[int, int]
         self.directions = directions  # type: int

--- a/spec/RSI.md
+++ b/spec/RSI.md
@@ -22,16 +22,15 @@ Key | Meaning
 
 A state is a container for metadata for a specific sprite sheet. They store data related to their sprite sheet like delays of animations and directions. A state has an accompanying sprite sheet.
 
-States have Two fields that can be used to distinguish them:
+States have one field that can be used to distinguish them:
 
 Key | Meaning
 --- | -------
 `name` | The name of the state. Can only contain lowercase alphabetic, numerical, and some special (`_-`) characters.
-`select` | A list of strings. There will be a very specific list of selectors and these can not be used arbitrarily. Optional.
 
-States cannot have all the same identifying values. A state with different flags and same name can thus exist, while two states with the same name and no flags will be incorrect.
+States cannot have the same identifying value. Two states with the same name may not exist.
 
-Other than identifiers, a state has two other fields in relation to the actual sprites as seen in game:
+Other than the identifier, a state has two other fields in relation to the actual sprites as seen in game:
 
 Key | Meaning
 --- | -------
@@ -57,7 +56,7 @@ These directions are ordered (for layout in the `delays` field and ordering in t
 
 #### Sprite sheet
 
-The PNG file accompanying a state is always the name of the state, with all selectors appended with plus characters, sorted alphabetically. For example, a state with name "hello" and selectors "x" and "y" would be `hello+x+y.png` on disk.
+The PNG file accompanying a state is always the name of the state. For example, a state with name "hello" would be `hello.png` on disk.
 
 The file contains the individual states resolved with the directions and delays of the state. The size of the file is always a multiple of the RSI's `size`. Sprites are ordered from the top left to the bottom right, always going horizontally first. The amount of sprites per row or column is always made to be as equal as possible, favoring rows to be longer than columns if the amount of states is not able to be divided perfectly.
 
@@ -81,7 +80,6 @@ Note that in practice the JSON writer probably writes the most compact JSON poss
     "states": [
         {
             "name": "hello",
-            "select": [],
             "flags": {},
             "directions": 4,
             "delays": [


### PR DESCRIPTION
Removes selector support in the scripts and modifies the spec accordingly.

[Sister PR.](https://github.com/space-wizards/RobustToolbox/pull/952)